### PR TITLE
re-add handling of import tags as deprecated

### DIFF
--- a/lib/DT.pm
+++ b/lib/DT.pm
@@ -33,6 +33,18 @@ use overload
 
 my $HAVE_PG;
 
+sub import {
+    shift;
+    for my $arg (@ARGV) {
+        if ($arg =~ /^:/) {
+            Carp::carp "Import tags ($arg) are deprecated!";
+        }
+        else {
+            Carp::croak "Unknown option $arg!";
+        }
+    }
+}
+
 sub new {
     my $class = shift;
 
@@ -245,8 +257,6 @@ Consider:
 
 Versus:
 
-    use DT ':pg';
-    
     my $dt_unix = DT->new(time);
     my $dt_pg = DT->new($timestamp_from_postgres);
     my $dt_iso = DT->new($iso_datetime);

--- a/t/03-pg.t
+++ b/t/03-pg.t
@@ -10,7 +10,10 @@ if ( $@ ) {
 
 plan tests => 7;
 
-eval { DT->import(':pg') };
+eval {
+    local $SIG{__WARN__} = sub {};
+    DT->import(':pg');
+};
 is $@, '', "import :pg no exception";
 
 my $dt = eval { DT->new('2018-02-07 21:22:09.58343-08') };


### PR DESCRIPTION
Future versions of perl are intending to make it an error to pass arguments to an undefined import method. This module was relying on the arguments to be ignored.

Re-add an import method that warns about the no longer needed tags, adjust the tests to account for that, and remove the example using :pg from the docs.